### PR TITLE
Add guards to prevent undefined index error when firstword or lastword are an empty string

### DIFF
--- a/pd3f/export.py
+++ b/pd3f/export.py
@@ -366,7 +366,7 @@ class Export:
         lastword = lastword.strip()
         firstword = text_next_line[0]
         firstword = firstword.strip()
-        if (lastword[-1] == '-') or (lastword[-1] == ',') or (firstword[0].islower()):
+        if (lastword and (lastword[-1] == '-' or lastword[-1] == ',')) or (firstword and firstword[0].islower()):
             #print("Case 3.1 end with -")
             return False
 


### PR DESCRIPTION
While testing, I noticed a couple of pdfs failing on index errors caused by either `firstword` or `lastword` not having a `[0]` or `[-1]`. This change adds tests for that.

I did not try to figure out whether `firstword` or `lastword` being an empty string was an error condition in itself.